### PR TITLE
Update programs_list.yml

### DIFF
--- a/programs_list.yml
+++ b/programs_list.yml
@@ -6,10 +6,11 @@
       - CSE@MIT
 - SS:
     CS:
+      - MSCV@CMU  
       - MLT@CMU
       - MSCS@CMU
       - MSML@CMU
-      - MSR@CMU
+
       - MCIS@UPenn
       - MSCS@UT-Austin
       - Two-Year MSCS@Yale
@@ -19,10 +20,10 @@
       - ICME@Stanford
 - S:
     CS:
+      - MSR@CMU
       - MCDS@CMU
       - MIIS@CMU
       - MSAII@CMU
-      - MSCV@CMU  
       - MSCS@UCLA
       - MSCS@UIUC
       - CS Meng@Cornell
@@ -43,7 +44,6 @@
       - MSCS@NWU
       - MCS@UIUC
       - MSCS@UBC
-      - MMath@Waterloo
       - MPhil-CSE@HKUST
     NONCS:
       - ECE Meng(coop)@Waterloo
@@ -51,8 +51,8 @@
 - A:
     CS:
       - SESV@CMU
-      - CSE@GaTech
       - CS75@UCSD
+      - MMath@Waterloo
       - CM@Cornell Tech
     NONCS:
       - MDSAI@Waterloo
@@ -86,6 +86,7 @@
       - MSCS@NYU Courant
       - MSCS@NYU Tandon
       - MCS@TAMU
+      - CSE@GaTech
       - MSCS@TAMU
       - MSWE@UCI
       - CS28@USC


### PR DESCRIPTION
1. MSR秒录，今年60多个人，MSCV同RI项目把好多顶会二作大佬wl然后reject，MSR的funding现在很难搞了，咋可能MSR是SS，MSCV是S？？？MSCV今年的学弟有伯克利来的，基本13个华人左右一半有顶会，MSR今年有211和下游985，之前MSCV rej的时候很伤心，感觉确实cv配的上SS
2. GT cse录了大量85均分，还有85均分生化环材的，申了秒录，我几个国内211的同学有环境的有EE的申coc都是86分左右，一个院那么多人，现在coc转博不好转了很严格，为啥能放A，感觉最多是B+
3. MMath@Waterloo感觉也可以低一档，但这个感觉问题差的不大，前俩感觉有大问题