### PR TITLE
 Update CS75@UCSD.md 

### DIFF
--- a/docs/CS75@UCSD.md
+++ b/docs/CS75@UCSD.md
@@ -39,7 +39,7 @@ CS76 和 CS75 的选课方案不一样，申请难度相对较低，但实际上
 
 不允许defer，defer还需要重新提交下一年申请，且不保证录取。
 
-收到offer，过几天application界面出现pid（学号）就可以排学生公寓了，甚至不用接offer就可以排！Waitlist是先到先得，房型志愿可以之后任意编辑调整，建议尽早占位:-)
+收到offer，过几天application界面出现pid(学号)就可以排学生公寓了，甚至不用接offer就可以排！Waitlist是先到先得，房型志愿可以之后任意编辑调整，建议尽早占位:-)
 
 [查看公寓预计排期](https://its-netweb.ucsd.edu/hdh-gfh-community-statistics/statistics.aspx#3)
 

--- a/docs/CS75@UCSD.md
+++ b/docs/CS75@UCSD.md
@@ -1,21 +1,23 @@
 ## 录取偏好
 
-录取非常非常玄学，似乎不看 research。录取难度和 track 关系不大
+录取非常非常玄学，似乎不看 research。录取难度和 track 关系不大，不同track选课无限制，提交毕业申请时候选择track。
 
 ## 代表性 dp
 
-【21fall】双非 GPA 94.68/100，3.98/4.0，G323 T103，无 Pub，一段实习两段科研，普通课程推 录取
+【24fall】BJTU(中外合办) CS major WES GPA 3.91/4.00 GRE 322 TOEFL 103 两段英国院校科研 一篇水Journal 一段大厂实习
 
 【22fall】SJTU CS 系录了系第一，以及 88-89 的两人，信安系录了 85 分和 86 分两位软背景正常的同学。
 
 【22fall】SCUT 89+/100 前 3% 一段实习，三段国内科研
+
+【21fall】双非 GPA 94.68/100，3.98/4.0，G323 T103，无 Pub，一段实习两段科研，普通课程推 录取
 
 
 ## 网申备注
 
 不能 update 材料
 
-喜欢在西海岸时间凌晨定时发送申请结果通知
+喜欢在西海岸时间凌晨定时（北京时间下午四点）发送申请结果通知
 
 【portal变化信息含义】：
 
@@ -29,13 +31,17 @@
 
 ## 项目特点
 
-size 不算小，官网给的数据是 21Fall 1,165 admits, 501 New Students。地理位置好，气候佳，大众情人校，因此申请非常卷。
+size 不算小，官网给的数据是 23Fall 578 admits, 266 New Students。地理位置好，气候佳，大众情人校，因此申请非常卷。
 
 CS76 和 CS75 的选课方案不一样，申请难度相对较低，但实际上进校之后很好转 CS75。如果第一学期 GPA 较高的话，第二学期就可以转，反之亦然。硬件背景更好的可以申 CS76 曲线救国。
 
-[官方Admission/Enrollment/Placement统计](https://ir.ucsd.edu/grad/index.html)
+[官方Admission/Enrollment/Placement统计](https://ir.ucsd.edu/stats/grad/admissions.html)
 
-不允许defer
+不允许defer，defer还需要重新提交下一年申请，且不保证录取。
+
+收到offer，过几天application界面出现pid（学号）就可以排学生公寓了，甚至不用接offer就可以排！Waitlist是先到先得，房型志愿可以之后任意编辑调整，建议尽早占位:-)
+
+[查看公寓预计排期](https://its-netweb.ucsd.edu/hdh-gfh-community-statistics/statistics.aspx#3)
 
 ## 申请季实时信息
 


### PR DESCRIPTION
# 根据自己24Fall dp和offer holder群了解的情况进行更新

## 代表性dp模块
代表性dp模块提供自己dp同时，调整顺序。私以为考虑到时效性，更新的dp应该在上面。

## Defer说明
<img width="886" alt="7060ad48a22c2f07e3f6fdc748dbb9b1" src="https://github.com/opencsapp/opencsapp.github.io/assets/71240100/c140090b-c612-4c36-b484-1b1c920e7dcb">

## 数据勘误
21Fall admit new students的数据误计算了PhD的数量。现已根据官网23Fall的数据进行了更新，并且修正了失效的链接。
> [官网数据](https://ir.ucsd.edu/stats/grad/admissions.html)
<img width="1004" alt="21Fall数据问题" src="https://github.com/opencsapp/opencsapp.github.io/assets/71240100/4927b752-5ccf-459c-89e1-7b4d1d4f9bae">


最后，感谢@xichenpan和@opencsapp，帮助大家选校方面事半功倍，offer多多。希望@opencsapp越来越好❤️