### PR TITLE
Update programs_list.yml

### DIFF
--- a/programs_list.yml
+++ b/programs_list.yml
@@ -64,6 +64,7 @@
       - DS@UMich
 - A-:
     CS:
+      - MSECS@JHU
       - ScM CS@Brown
       - MSCS@Columbia
       - MSCS@Dartmouth
@@ -109,7 +110,6 @@
       - MSCSE@UCSC
       - MSCS&SE@UWB
       - NetSys@UCI
-      - MSECS@JHU
       - MCS@uOttawa
       - MSCS@Western
       - CE MEng@TAMU


### PR DESCRIPTION
JHU MSECS bar明显上升，很多能录Columbia/Brown/UPenn的不一定能录JHU。而且学校科研实力强NLP排名巨高仅次于UW，Stanford，CMU等。btw谢谢opencs的大家！！