### PR TITLE
Move CMU MSE-SS from B+ to A

### DIFF
--- a/programs_list.yml
+++ b/programs_list.yml
@@ -53,6 +53,7 @@
 - A:
     CS:
       - SESV@CMU
+      - MSE-SS@CMU
       - CS75@UCSD
       - CM@Cornell Tech
     NONCS:
@@ -85,7 +86,6 @@
       - MEng@UCLA
 - B+:
     CS:
-      - MSE-SS@CMU
       - MSCS@NYU Courant
       - MSCS@NYU Tandon
       - MCS@TAMU


### PR DESCRIPTION
25 fall 季申请， 同录取了Cornell Tech Meng CS。MSE-SS 申请难度和SESV 差不多而且outcome 也不错，认为跟MSIN 统一梯队。